### PR TITLE
Add OpenAI Codex and Google Gemini CLI to Dockerfile

### DIFF
--- a/bash/Dockerfile
+++ b/bash/Dockerfile
@@ -94,10 +94,10 @@ RUN chmod +x /bin/entry.sh && \
 
 USER jovyan
 
-# Install Claude Code
+# Install Claude Code, OpenAI Codex, and Google Gemini CLI
 RUN npm config set prefix /home/jovyan/.npm-global && \
     export PATH=/home/jovyan/.npm-global/bin:$PATH && \
-    npm install -g @anthropic-ai/claude-code
+    npm install -g @anthropic-ai/claude-code @openai/codex @google/gemini-cli
 
 # Configure bashrc
 RUN echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \


### PR DESCRIPTION
Install @openai/codex and @google/gemini-cli npm packages alongside Claude Code to provide users with additional AI coding assistant tools.

- @openai/codex: OpenAI's official CLI tool (v0.57.0)
- @google/gemini-cli: Google's official Gemini CLI with 1M token context window

All three AI CLIs are now available in the bash variant of the cloud shell environment.