### PR TITLE
fix: update git-credential-manager v2.7.0 → v2.7.3 + dependency audit

### DIFF
--- a/bash/Dockerfile
+++ b/bash/Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get update && \
 RUN wget -q -c https://dl.google.com/go/go1.25.5.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
 
 # install ttyd
-RUN curl -L "https://github.com/tsl0922/ttyd/releases/download/1.7.8/ttyd.x86_64" > ttyd && \
+RUN curl -L "https://github.com/tsl0922/ttyd/releases/download/1.7.7/ttyd.x86_64" > ttyd && \
     chmod a+x ttyd && \
     mv ttyd /usr/local/bin/ttyd
 
@@ -69,10 +69,10 @@ COPY 01-custom /etc/motd
 RUN chmod +x /etc/motd
 
 # install git-credential-manager
-RUN wget https://github.com/git-ecosystem/git-credential-manager/releases/download/v2.7.0/gcm-linux_amd64.2.7.0.deb && \
+RUN wget https://github.com/git-ecosystem/git-credential-manager/releases/download/v2.7.3/gcm-linux-x64-2.7.3.deb && \
     apt-get update && \
-    apt-get install -y ./gcm-linux_amd64.2.7.0.deb && \
-    rm gcm-linux_amd64.2.7.0.deb && \
+    apt-get install -y ./gcm-linux-x64-2.7.3.deb && \
+    rm gcm-linux-x64-2.7.3.deb && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

The Docker build has been failing for 3+ weeks due to 404 errors on hardcoded asset URLs in `bash/Dockerfile`.

### What was broken
- **git-credential-manager v2.7.0**: The release asset was removed/renamed. The v2.7.3 release also changed the naming scheme from `gcm-linux_amd64` to `gcm-linux-x64`.
- **ttyd 1.7.8**: This version does not exist. The latest release is 1.7.7.

### What was fixed
- Updated GCM from v2.7.0 → v2.7.3 with corrected asset filename (`gcm-linux-x64-2.7.3.deb`)
- Downgraded ttyd from 1.7.8 → 1.7.7 (the actual latest release)

### Dependency audit
Verified all other pinned URLs still resolve (HTTP 200/302):
- tini v0.19.0 ✓
- Go 1.25.5 ✓
- NodeSource 22.x ✓
- GoCommands (dynamic version) ✓

## Test plan
- [ ] Verify the Docker image builds successfully in CI
- [ ] Run the container locally with `docker run -it -p 7681:7681` and confirm ttyd serves a terminal
- [ ] Verify `git-credential-manager --version` returns 2.7.3 inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)