### PR TITLE
fix: replace claude.ai installer with npm, fix PATH for all AI CLIs

### DIFF
--- a/bash/Dockerfile
+++ b/bash/Dockerfile
@@ -107,25 +107,22 @@ RUN chmod +x /bin/entry.sh && \
 
 USER jovyan
 
-# Install Claude Code using official installer
-RUN curl -fsSL https://claude.ai/install.sh | bash
-
-# Install OpenAI Codex and Google Gemini CLI via npm
+# Install Claude Code, OpenAI Codex, and Google Gemini CLI via npm
+# (npm install is preferred over claude.ai/install.sh for Docker builds)
 RUN npm config set prefix /home/jovyan/.npm-global && \
-    export PATH=/home/jovyan/.npm-global/bin:$PATH && \
-    npm install -g @google/gemini-cli @openai/codex
+    npm install -g @anthropic-ai/claude-code @google/gemini-cli @openai/codex && \
+    npm cache clean --force
 
 # Install OpenCode (https://opencode.ai/)
 RUN curl -fsSL https://opencode.ai/install | bash
-ENV PATH="/home/jovyan/.opencode/bin:${PATH}"
 
 # Configure bashrc
 RUN echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo '[ ! -z "$TERM" -a -r /etc/motd ] && /etc/motd' >> ~/.bashrc && \
     echo $'\n# upgrade GoCommands\nsudo gocmd upgrade > /dev/null' >> ~/.bashrc
 
-# set path for Go and NPM
-ENV PATH=$PATH:/usr/local/go/bin:/home/jovyan/.npm-global/bin
+# set path for Go, NPM globals, and OpenCode
+ENV PATH="/home/jovyan/.npm-global/bin:/home/jovyan/.opencode/bin:/usr/local/go/bin:${PATH}"
 
 # set shell as bash and terminal as linux
 ENV SHELL=bash


### PR DESCRIPTION
## Problem
- `curl -fsSL https://claude.ai/install.sh | bash` is unreliable in Docker builds (non-interactive, network-dependent)
- The claude binary was installed to `~/.claude/local/` but that path was never added to ENV PATH
- Users couldn't access `claude` from the terminal

## Changes
- Replace `curl claude.ai/install.sh | bash` → `npm install -g @anthropic-ai/claude-code` (same approach used in vscode, jupyterlab, rstudio containers)
- Consolidate Claude Code, Gemini CLI, and Codex into single `npm install` RUN
- Add `/home/jovyan/.npm-global/bin` and `/home/jovyan/.opencode/bin` to ENV PATH so all 4 tools are reachable from any terminal session

## Tools available after this fix
- ✅ `claude` — Claude Code
- ✅ `gemini` — Gemini CLI  
- ✅ `codex` — OpenAI Codex
- ✅ `opencode` — Open Code (already present, PATH was incomplete)

Users provide their own API keys / login to their accounts.
