### PR TITLE
fix: add --no-modify-path to opencode install (prevent Docker build hang)

### DIFF
--- a/bash/Dockerfile
+++ b/bash/Dockerfile
@@ -113,8 +113,8 @@ RUN npm config set prefix /home/jovyan/.npm-global && \
     npm install -g @anthropic-ai/claude-code @google/gemini-cli @openai/codex && \
     npm cache clean --force
 
-# Install OpenCode (https://opencode.ai/)
-RUN curl -fsSL https://opencode.ai/install | bash
+# Install OpenCode (https://opencode.ai/) — --no-modify-path avoids shell detection hang in Docker
+RUN curl -fsSL https://opencode.ai/install | bash -s -- --no-modify-path
 
 # Configure bashrc
 RUN echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \


### PR DESCRIPTION
fix: add --no-modify-path to opencode install

The opencode installer tries to detect the current shell and modify config files (.bashrc, .zshrc, etc.). In a Docker build context this can hang indefinitely since there's no interactive shell to detect.

Adding `--no-modify-path` skips that step entirely — PATH is already set via the ENV instruction.